### PR TITLE
Add some tests (and fix a couple of things)

### DIFF
--- a/src/main/java/dev/hbeck/kdl/objects/KDLValue.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLValue.java
@@ -1,6 +1,8 @@
 package dev.hbeck.kdl.objects;
 
 import java.util.Optional;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 
 public interface KDLValue extends KDLObject {
     KDLString getAsString();
@@ -23,5 +25,28 @@ public interface KDLValue extends KDLObject {
 
     default boolean isNull() {
         return false;
+    }
+
+    static KDLValue from(Object o) {
+        if (o == null) return KDLNull.INSTANCE;
+        if (o instanceof Boolean) {
+            if ((Boolean) o) return KDLBoolean.TRUE;
+            return KDLBoolean.FALSE;
+        }
+        if (o instanceof BigInteger) {
+            return new KDLNumber(new BigDecimal((BigInteger)o), 10);
+        }
+        if (o instanceof BigDecimal) {
+            return new KDLNumber((BigDecimal)o, 10);
+        }
+        if (o instanceof Number) {
+            return new KDLNumber(new BigDecimal(o.toString()), 10);
+        }
+        if (o instanceof String) {
+            return new KDLString((String)o);
+        }
+        if (o instanceof KDLValue) return (KDLValue)o;
+
+        throw new RuntimeException("No KDLValue for object " + o.toString());
     }
 }

--- a/src/main/java/dev/hbeck/kdl/parse/KDLParser.java
+++ b/src/main/java/dev/hbeck/kdl/parse/KDLParser.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 public class KDLParser {
 
     public static final int EOF = -1;
-    public static final int MAX_UNICODE = 0x10FFF;
+    public static final int MAX_UNICODE = 0x10FFFF;
 
     private static final Set<Integer> NUMERIC_START_CHARS =
             Stream.of('+', '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9')

--- a/src/main/java/dev/hbeck/kdl/parse/KDLParser.java
+++ b/src/main/java/dev/hbeck/kdl/parse/KDLParser.java
@@ -211,6 +211,9 @@ public class KDLParser {
                         return Optional.of(new KDLNode(identifier, properties, args, child));
                     } else if (UNICODE_LINESPACE.contains(c) || c == EOF) {
                         return Optional.of(new KDLNode(identifier, properties, args, child));
+                    } else if (c == ';') {
+                        context.read();
+                        return Optional.of(new KDLNode(identifier, properties, args, child));
                     } else {
                         throw new KDLParseException(String.format("Unexpected character: '%s'", (char) c));
                     }

--- a/src/main/java/dev/hbeck/kdl/parse/KDLParser.java
+++ b/src/main/java/dev/hbeck/kdl/parse/KDLParser.java
@@ -478,7 +478,7 @@ public class KDLParser {
             } else if (c == '"' && !inEscape) {
                 return stringBuilder.toString();
             } else if (inEscape) {
-                stringBuilder.append((char) getEscaped(c, context));
+                stringBuilder.append(getEscaped(c, context));
                 inEscape = false;
             } else if (c == EOF) {
                 throw new KDLParseException("EOF while reading an escaped string");
@@ -488,22 +488,24 @@ public class KDLParser {
         }
     }
 
-    int getEscaped(int c, KDLParseContext context) throws IOException {
+    String getEscaped(int c, KDLParseContext context) throws IOException {
         switch (c) {
             case 'n':
-                return '\n';
+                return "\n";
             case 'r':
-                return '\r';
+                return "\r";
             case 't':
-                return '\t';
+                return "\t";
             case '\\':
-                return '\\';
+                return "\\";
+            case '/':
+                return "/";
             case '"':
-                return '\"';
+                return "\"";
             case 'b':
-                return '\b';
+                return "\b";
             case 'f':
-                return '\f';
+                return "\f";
             case 'u': {
                 final StringBuilder stringBuilder = new StringBuilder(6);
                 c = context.read();
@@ -538,7 +540,7 @@ public class KDLParser {
                 if (code < 0 || MAX_UNICODE < code) {
                     throw new KDLParseException(String.format("Unicode code point is outside allowed range [0, %x]: %x", MAX_UNICODE, code));
                 } else {
-                    return code;
+                    return new String(Character.toChars(code));
                 }
             }
             default:

--- a/src/main/java/dev/hbeck/kdl/parse/KDLParser.java
+++ b/src/main/java/dev/hbeck/kdl/parse/KDLParser.java
@@ -473,7 +473,7 @@ public class KDLParser {
         boolean inEscape = false;
         while (true) {
             c = context.read();
-            if (c == '\\') {
+            if (!inEscape && c == '\\') {
                 inEscape = true;
             } else if (c == '"' && !inEscape) {
                 return stringBuilder.toString();

--- a/src/main/java/dev/hbeck/kdl/parse/KDLParser.java
+++ b/src/main/java/dev/hbeck/kdl/parse/KDLParser.java
@@ -478,7 +478,7 @@ public class KDLParser {
             } else if (c == '"' && !inEscape) {
                 return stringBuilder.toString();
             } else if (inEscape) {
-                stringBuilder.append(getEscaped(c, context));
+                stringBuilder.appendCodePoint(getEscaped(c, context));
                 inEscape = false;
             } else if (c == EOF) {
                 throw new KDLParseException("EOF while reading an escaped string");
@@ -488,24 +488,24 @@ public class KDLParser {
         }
     }
 
-    String getEscaped(int c, KDLParseContext context) throws IOException {
+    int getEscaped(int c, KDLParseContext context) throws IOException {
         switch (c) {
             case 'n':
-                return "\n";
+                return '\n';
             case 'r':
-                return "\r";
+                return '\r';
             case 't':
-                return "\t";
+                return '\t';
             case '\\':
-                return "\\";
+                return '\\';
             case '/':
-                return "/";
+                return '/';
             case '"':
-                return "\"";
+                return '\"';
             case 'b':
-                return "\b";
+                return '\b';
             case 'f':
-                return "\f";
+                return '\f';
             case 'u': {
                 final StringBuilder stringBuilder = new StringBuilder(6);
                 c = context.read();
@@ -540,7 +540,7 @@ public class KDLParser {
                 if (code < 0 || MAX_UNICODE < code) {
                     throw new KDLParseException(String.format("Unicode code point is outside allowed range [0, %x]: %x", MAX_UNICODE, code));
                 } else {
-                    return new String(Character.toChars(code));
+                    return code;
                 }
             }
             default:

--- a/src/test/java/dev/hbeck/kdl/TestUtil.java
+++ b/src/test/java/dev/hbeck/kdl/TestUtil.java
@@ -3,6 +3,12 @@ package dev.hbeck.kdl;
 import dev.hbeck.kdl.parse.KDLParseContext;
 import dev.hbeck.kdl.parse.KDLParser;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.Description;
+
 import java.io.IOException;
 import java.io.StringReader;
 
@@ -28,4 +34,45 @@ public class TestUtil {
 
         return stringBuilder.toString();
     }
+
+    public static Matcher<Runnable> throwsException(Class exceptionClass) {
+      return new ThrowsExceptionMatcher(exceptionClass);
+    }
+}
+
+class ThrowsExceptionMatcher extends TypeSafeMatcher<Runnable> {
+
+  private final Class exceptionClass;
+  private Exception actualException;
+
+  public ThrowsExceptionMatcher(Class exceptionClass) {
+    this.exceptionClass = exceptionClass;
+  }
+
+  @Override
+  protected boolean matchesSafely(Runnable fn) {
+    try {
+      fn.run();
+      return false;
+    } catch (Exception e) {
+      actualException = e;
+      return e.getClass() == exceptionClass;
+    }
+  }
+
+  @Override
+  public void describeTo(Description description) {
+    description.appendText("throws exception ");
+    description.appendValue(exceptionClass.toString());
+  }
+
+  @Override
+  protected void describeMismatchSafely(Runnable item, Description description) {
+    if (actualException != null) {
+      description.appendText("threw exception ");
+      description.appendValue(actualException);
+    } else {
+      description.appendText("threw no exception");
+    }
+  }
 }

--- a/src/test/java/dev/hbeck/kdl/parse/TestGetEscaped.java
+++ b/src/test/java/dev/hbeck/kdl/parse/TestGetEscaped.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(Parameterized.class)
 public class TestGetEscaped {
-    public TestGetEscaped(String input, String expectedResult) {
+    public TestGetEscaped(String input, int expectedResult) {
         this.input = input;
         this.expectedResult = expectedResult;
     }
@@ -23,32 +23,35 @@ public class TestGetEscaped {
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> getCases() {
         return Stream.of(
-                new Object[]{"n", "\n"},
-                new Object[]{"r", "\r"},
-                new Object[]{"t", "\t"},
-                new Object[]{"\\", "\\"},
-                new Object[]{"\"", "\""},
-                new Object[]{"b", "\b"},
-                new Object[]{"f", "\f"},
-                new Object[]{"u{1}", "\u0001"},
-                new Object[]{"u{01}", "\u0001"},
-                new Object[]{"u{001}", "\u0001"},
-                new Object[]{"u{001}", "\u0001"},
-                new Object[]{"u{0001}", "\u0001"},
-                new Object[]{"u{00001}", "\u0001"},
-                new Object[]{"u{000001}", "\u0001"},
-                new Object[]{"ux", ""},
-                new Object[]{"u{x}", ""},
-                new Object[]{"u{0001", ""},
-                new Object[]{"u{AX}", ""},
-                new Object[]{"u{}", ""},
-                new Object[]{"u{0000001}", ""},
-                new Object[]{"u{110000}", ""}
+                new Object[]{"n", '\n'},
+                new Object[]{"r", '\r'},
+                new Object[]{"t", '\t'},
+                new Object[]{"\\", '\\'},
+                new Object[]{"/", '/'},
+                new Object[]{"\"", '\"'},
+                new Object[]{"b", '\b'},
+                new Object[]{"f", '\f'},
+                new Object[]{"u{1}", '\u0001'},
+                new Object[]{"u{01}", '\u0001'},
+                new Object[]{"u{001}", '\u0001'},
+                new Object[]{"u{001}", '\u0001'},
+                new Object[]{"u{0001}", '\u0001'},
+                new Object[]{"u{00001}", '\u0001'},
+                new Object[]{"u{000001}", '\u0001'},
+                new Object[]{"u{10FFFF}", 0x10FFFF},
+                new Object[]{"i", -2},
+                new Object[]{"ux", -2},
+                new Object[]{"u{x}", -2},
+                new Object[]{"u{0001", -2},
+                new Object[]{"u{AX}", -2},
+                new Object[]{"u{}", -2},
+                new Object[]{"u{0000001}", -2},
+                new Object[]{"u{110000}", -2}
         ).collect(Collectors.toList());
     }
 
     private final String input;
-    private final String expectedResult;
+    private final int expectedResult;
 
     @Test
     public void doTest() throws IOException {
@@ -56,10 +59,10 @@ public class TestGetEscaped {
         final int initial = context.read();
 
         try {
-            final String result = TestUtil.parser.getEscaped(initial, context);
+            final int result = TestUtil.parser.getEscaped(initial, context);
             assertThat(result, equalTo(expectedResult));
         } catch (KDLParseException e) {
-            if (expectedResult != "") {
+            if (expectedResult > 0) {
                 throw new KDLParseException("Expected no errors", e);
             }
         }

--- a/src/test/java/dev/hbeck/kdl/parse/TestGetEscaped.java
+++ b/src/test/java/dev/hbeck/kdl/parse/TestGetEscaped.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(Parameterized.class)
 public class TestGetEscaped {
-    public TestGetEscaped(String input, int expectedResult) {
+    public TestGetEscaped(String input, String expectedResult) {
         this.input = input;
         this.expectedResult = expectedResult;
     }
@@ -23,32 +23,32 @@ public class TestGetEscaped {
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> getCases() {
         return Stream.of(
-                new Object[]{"n", '\n'},
-                new Object[]{"r", '\r'},
-                new Object[]{"t", '\t'},
-                new Object[]{"\\", '\\'},
-                new Object[]{"\"", '\"'},
-                new Object[]{"b", '\b'},
-                new Object[]{"f", '\f'},
-                new Object[]{"u{1}", '\u0001'},
-                new Object[]{"u{01}", '\u0001'},
-                new Object[]{"u{001}", '\u0001'},
-                new Object[]{"u{001}", '\u0001'},
-                new Object[]{"u{0001}", '\u0001'},
-                new Object[]{"u{00001}", '\u0001'},
-                new Object[]{"u{000001}", '\u0001'},
-                new Object[]{"ux", -2},
-                new Object[]{"u{x}", -2},
-                new Object[]{"u{0001", -2},
-                new Object[]{"u{AX}", -2},
-                new Object[]{"u{}", -2},
-                new Object[]{"u{0000001}", -2},
-                new Object[]{"u{11FFF}", -2}
+                new Object[]{"n", "\n"},
+                new Object[]{"r", "\r"},
+                new Object[]{"t", "\t"},
+                new Object[]{"\\", "\\"},
+                new Object[]{"\"", "\""},
+                new Object[]{"b", "\b"},
+                new Object[]{"f", "\f"},
+                new Object[]{"u{1}", "\u0001"},
+                new Object[]{"u{01}", "\u0001"},
+                new Object[]{"u{001}", "\u0001"},
+                new Object[]{"u{001}", "\u0001"},
+                new Object[]{"u{0001}", "\u0001"},
+                new Object[]{"u{00001}", "\u0001"},
+                new Object[]{"u{000001}", "\u0001"},
+                new Object[]{"ux", ""},
+                new Object[]{"u{x}", ""},
+                new Object[]{"u{0001", ""},
+                new Object[]{"u{AX}", ""},
+                new Object[]{"u{}", ""},
+                new Object[]{"u{0000001}", ""},
+                new Object[]{"u{110000}", ""}
         ).collect(Collectors.toList());
     }
 
     private final String input;
-    private final int expectedResult;
+    private final String expectedResult;
 
     @Test
     public void doTest() throws IOException {
@@ -56,10 +56,10 @@ public class TestGetEscaped {
         final int initial = context.read();
 
         try {
-            final int result = TestUtil.parser.getEscaped(initial, context);
+            final String result = TestUtil.parser.getEscaped(initial, context);
             assertThat(result, equalTo(expectedResult));
         } catch (KDLParseException e) {
-            if (expectedResult > 0) {
+            if (expectedResult != "") {
                 throw new KDLParseException("Expected no errors", e);
             }
         }

--- a/src/test/java/dev/hbeck/kdl/parse/TestParser.java
+++ b/src/test/java/dev/hbeck/kdl/parse/TestParser.java
@@ -1,0 +1,369 @@
+package dev.hbeck.kdl.parse;
+
+import dev.hbeck.kdl.objects.*;
+import static dev.hbeck.kdl.TestUtil.parser;
+import static dev.hbeck.kdl.TestUtil.throwsException;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Map.Entry;
+import java.util.Collections;
+import java.util.Optional;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class TestParser {
+    @Test
+    public void test_parseEmptyString() {
+        assertThat(parser.parse(""), equalTo(doc()));
+        assertThat(parser.parse(" "), equalTo(doc()));
+        assertThat(parser.parse("\n"), equalTo(doc()));
+    }
+
+    @Test
+    public void test_nodes() {
+        assertThat(parser.parse("node"), equalTo(doc(node("node"))));
+        assertThat(parser.parse("node\n"), equalTo(doc(node("node"))));
+        assertThat(parser.parse("\nnode\n"), equalTo(doc(node("node"))));
+        assertThat(parser.parse("node1\nnode2"),
+            equalTo(doc(node("node1"), node("node2"))));
+    }
+
+    @Test
+    public void test_node() {
+        assertThat(parser.parse("node;"), equalTo(doc(node("node"))));
+        assertThat(parser.parse("node 1"), equalTo(doc(node("node", List.of(1)))));
+        assertThat(parser.parse("node 1 2 \"3\" true false null"),
+            equalTo(doc(node("node", List.of(1, 2, "3", true, false, KDLNull.INSTANCE)))));
+        assertThat(parser.parse("node {\n    node2\n}"),
+            equalTo(doc(node("node", node("node2")))));
+    }
+
+    @Test
+    public void test_slashDashComment() {
+        assertThat(parser.parse("/-node"), equalTo(doc()));
+        assertThat(parser.parse("/- node"), equalTo(doc()));
+        assertThat(parser.parse("/- node\n"), equalTo(doc()));
+        assertThat(parser.parse("/-node 1 2 3"), equalTo(doc()));
+        assertThat(parser.parse("/-node key=false"), equalTo(doc()));
+        assertThat(parser.parse("/-node{\nnode\n}"), equalTo(doc()));
+        assertThat(parser.parse("/-node 1 2 3 key=\"value\" \\\n{\nnode\n}"), equalTo(doc()));
+    }
+
+    @Test
+    public void test_argSlashdashComment() {
+        assertThat(parser.parse("node /-1"), equalTo(doc(node("node"))));
+        assertThat(parser.parse("node /-1 2"), equalTo(doc(node("node", List.of(2)))));
+        assertThat(parser.parse("node 1 /- 2 3"), equalTo(doc(node("node", List.of(1, 3)))));
+        assertThat(parser.parse("node /--1"), equalTo(doc(node("node"))));
+        assertThat(parser.parse("node /- -1"), equalTo(doc(node("node"))));
+        assertThat(parser.parse("node \\\n/- -1"), equalTo(doc(node("node"))));
+    }
+
+    @Test
+    public void test_prop_slashdash_comment() {
+        assertThat(parser.parse("node /-key=1"), equalTo(doc(node("node"))));
+        assertThat(parser.parse("node /- key=1"), equalTo(doc(node("node"))));
+        assertThat(parser.parse("node key=1 /-key2=2"), equalTo(doc(node("node", Map.of("key", 1)))));
+    }
+
+    @Test
+    public void test_childrenSlashdashComment() {
+        assertThat(parser.parse("node /-{}"), equalTo(doc(node("node"))));
+        assertThat(parser.parse("node /- {}"), equalTo(doc(node("node"))));
+        assertThat(parser.parse("node /-{\nnode2\n}"), equalTo(doc(node("node"))));
+    }
+
+    @Test
+    public void test_string() {
+        assertThat(parser.parse("node \"\""), equalTo(doc(node("node", List.of("")))));
+        assertThat(parser.parse("node \"hello\""), equalTo(doc(node("node", List.of("hello")))));
+        assertThat(parser.parse("node \"hello\\nworld\""), equalTo(doc(node("node", List.of("hello\nworld")))));
+        assertThat(parser.parse("node \"\\u{1F408}\""), equalTo(doc(node("node", List.of("\uD83D\uDC08")))));
+        assertThat(parser.parse("node \"\\\"\\\\\\/\\b\\f\\n\\r\\t\""),
+            equalTo(doc(node("node", List.of("\"\\/\u0008\u000C\n\r\t")))));
+        assertThat(parser.parse("node \"\\u{10}\""), equalTo(doc(node("node", List.of("\u0010")))));
+
+        assertThat(() -> parser.parse("node \"\\i\""), throwsException(KDLParseException.class));
+        assertThat(() -> parser.parse("node \"\\u{c0ffee}\""), throwsException(KDLParseException.class));
+    }
+
+    @Test
+    public void test_float() {
+        assertThat(parser.parse("node 1.0"), equalTo(doc(node("node", List.of(1.0)))));
+        assertThat(parser.parse("node 0.0"), equalTo(doc(node("node", List.of(0.0)))));
+        assertThat(parser.parse("node -1.0"), equalTo(doc(node("node", List.of(-1.0)))));
+        assertThat(parser.parse("node +1.0"), equalTo(doc(node("node", List.of(1.0)))));
+        assertThat(parser.parse("node 1.0e10"), equalTo(doc(node("node", List.of(1.0e10)))));
+        assertThat(parser.parse("node 1.0e-10"), equalTo(doc(node("node", List.of(1.0e-10)))));
+        assertThat(parser.parse("node 123_456_789.0"),
+            equalTo(doc(node("node", List.of(new BigDecimal("123456789.0"))))));
+        assertThat(parser.parse("node 123_456_789.0_"),
+            equalTo(doc(node("node", List.of(new BigDecimal("123456789.0"))))));
+
+        assertThat(() -> parser.parse("node ?1.0"), throwsException(KDLParseException.class));
+        assertThat(() -> parser.parse("node _1.0"), throwsException(KDLParseException.class));
+        assertThat(() -> parser.parse("node .0"), throwsException(KDLParseException.class));
+        assertThat(() -> parser.parse("node 1._0"), throwsException(KDLParseException.class)); // TODO: fails
+        assertThat(() -> parser.parse("node 1."), throwsException(KDLParseException.class)); // TODO: fails
+    }
+
+    @Test
+    public void test_integer() {
+        assertThat(parser.parse("node 0"), equalTo(doc(node("node", List.of(0)))));
+        assertThat(parser.parse("node 0123456789"), equalTo(doc(node("node", List.of(123456789)))));
+        assertThat(parser.parse("node 0123_456_789"), equalTo(doc(node("node", List.of(123456789)))));
+        assertThat(parser.parse("node 0123_456_789_"), equalTo(doc(node("node", List.of(123456789)))));
+        assertThat(parser.parse("node +0123456789"), equalTo(doc(node("node", List.of(123456789)))));
+        assertThat(parser.parse("node -0123456789"), equalTo(doc(node("node", List.of(-123456789)))));
+
+        assertThat(() -> parser.parse("node ?0123456789"), throwsException(KDLParseException.class));
+        assertThat(() -> parser.parse("node _0123456789"), throwsException(KDLParseException.class));
+        assertThat(() -> parser.parse("node a"), throwsException(KDLParseException.class));
+        assertThat(() -> parser.parse("node --"), throwsException(KDLParseException.class));
+    }
+
+    @Test
+    public void test_hexadecimal() {
+        KDLNumber kdlNumber = new KDLNumber(new BigDecimal(new BigInteger("0123456789abcdef", 16)), 16);
+
+        assertThat(parser.parse("node 0x0123456789abcdef"), equalTo(doc(node("node", List.of(kdlNumber)))));
+        assertThat(parser.parse("node 0x01234567_89abcdef"), equalTo(doc(node("node", List.of(kdlNumber)))));
+        assertThat(parser.parse("node 0x01234567_89abcdef_"), equalTo(doc(node("node", List.of(kdlNumber)))));
+        
+        assertThat(() -> parser.parse("node 0x_123"), throwsException(KDLParseException.class));
+        assertThat(() -> parser.parse("node 0xg"), throwsException(KDLParseException.class));
+        assertThat(() -> parser.parse("node 0xx"), throwsException(KDLParseException.class));
+    }
+
+    @Test
+    public void test_octal() {
+        KDLNumber kdlNumber = new KDLNumber(new BigDecimal(01234567), 8);
+
+        assertThat(parser.parse("node 0o01234567"), equalTo(doc(node("node", List.of(kdlNumber)))));
+        assertThat(parser.parse("node 0o0123_4567"), equalTo(doc(node("node", List.of(kdlNumber)))));
+        assertThat(parser.parse("node 0o01234567_"), equalTo(doc(node("node", List.of(kdlNumber)))));
+
+        assertThat(() -> parser.parse("node 0o_123"), throwsException(KDLParseException.class));
+        assertThat(() -> parser.parse("node 0o8"), throwsException(KDLParseException.class));
+        assertThat(() -> parser.parse("node 0oo"), throwsException(KDLParseException.class));
+    }
+
+    @Test
+    public void test_binary() {
+        KDLNumber kdlNumber = new KDLNumber(new BigDecimal(6), 2);
+
+        assertThat(parser.parse("node 0b0110"), equalTo(doc(node("node", List.of(kdlNumber)))));
+        assertThat(parser.parse("node 0b01_10"), equalTo(doc(node("node", List.of(kdlNumber)))));
+        assertThat(parser.parse("node 0b01___10"), equalTo(doc(node("node", List.of(kdlNumber)))));
+        assertThat(parser.parse("node 0b0110_"), equalTo(doc(node("node", List.of(kdlNumber)))));
+
+        assertThat(() -> parser.parse("node 0b_0110"), throwsException(KDLParseException.class));
+        assertThat(() -> parser.parse("node 0b20"), throwsException(KDLParseException.class));
+        assertThat(() -> parser.parse("node 0bb"), throwsException(KDLParseException.class));
+    }
+
+    @Test
+    public void test_raw_string() {
+        assertThat(parser.parse("node r\"foo\""), equalTo(doc(node("node", List.of("foo")))));
+        assertThat(parser.parse("node r\"foo\\nbar\""), equalTo(doc(node("node", List.of("foo\\nbar")))));
+        assertThat(parser.parse("node r#\"foo\"#"), equalTo(doc(node("node", List.of("foo")))));
+        assertThat(parser.parse("node r##\"foo\"##"), equalTo(doc(node("node", List.of("foo")))));
+        assertThat(parser.parse("node r\"\\nfoo\\r\""), equalTo(doc(node("node", List.of("\\nfoo\\r")))));
+        assertThat(parser.parse("node r#\"hello\"world\"#"), equalTo(doc(node("node", List.of("hello\"world")))));
+    
+        assertThat(() -> parser.parse("node r##\"foo\"#"), throwsException(KDLParseException.class));
+    }
+
+    @Test
+    public void test_boolean() {
+        assertThat(parser.parse("node true"), equalTo(doc(node("node", List.of(true)))));
+        assertThat(parser.parse("node false"), equalTo(doc(node("node", List.of(false)))));
+    }
+
+    @Test
+    public void test_node_space() {
+        assertThat(parser.parse("node 1"), equalTo(doc(node("node", List.of(1)))));
+        assertThat(parser.parse("node\t1"), equalTo(doc(node("node", List.of(1)))));
+        assertThat(parser.parse("node\t \\\n 1"), equalTo(doc(node("node", List.of(1)))));
+        assertThat(parser.parse("node\t \\ // hello\n 1"), equalTo(doc(node("node", List.of(1))))); // TODO: fails
+    }
+
+    @Test
+    public void test_single_line_comment() {
+        assertThat(parser.parse("//hello"), equalTo(doc()));
+        assertThat(parser.parse("// \thello"), equalTo(doc()));
+        assertThat(parser.parse("//hello\n"), equalTo(doc()));
+        assertThat(parser.parse("//hello\r\n"), equalTo(doc()));
+        assertThat(parser.parse("//hello\n\r"), equalTo(doc()));
+        assertThat(parser.parse("//hello\rworld"), equalTo(doc(node("world"))));
+        assertThat(parser.parse("//hello\nworld\r\n"), equalTo(doc(node("world"))));
+    }
+
+    @Test
+    public void test_multi_line_comment() {
+        assertThat(parser.parse("/*hello*/"), equalTo(doc()));
+        assertThat(parser.parse("/*hello*/\n"), equalTo(doc()));
+        assertThat(parser.parse("/*\nhello\r\n*/"), equalTo(doc()));
+        assertThat(parser.parse("/*\nhello** /\n*/"), equalTo(doc()));
+        assertThat(parser.parse("/**\nhello** /\n*/"), equalTo(doc()));
+        assertThat(parser.parse("/*hello*/world"), equalTo(doc(node("world"))));
+    }
+
+    @Test
+    public void test_escline() {
+        assertThat(parser.parse("\\\nfoo"), equalTo(doc(node("foo"))));
+        assertThat(parser.parse("\\\n    foo"), equalTo(doc(node("foo"))));
+        assertThat(parser.parse("\\    \t \nfoo"), equalTo(doc(node("foo")))); // TODO: fails
+        assertThat(parser.parse("\\ // test \nfoo"), equalTo(doc(node("foo")))); // TODO: fails
+        assertThat(parser.parse("\\ // test \n    foo"), equalTo(doc(node("foo")))); // TODO: fails
+    }
+
+    @Test
+    public void test_whitespace() {
+        assertThat(parser.parse(" node"), equalTo(doc(node("node"))));
+        assertThat(parser.parse("\tnode"), equalTo(doc(node("node"))));
+        assertThat(parser.parse("/* \nfoo\r\n */ etc"), equalTo(doc(node("etc"))));
+    }
+
+    @Test
+    public void test_newline() {
+        assertThat(parser.parse("node1\nnode2"), equalTo(doc(node("node1"), node("node2"))));
+        assertThat(parser.parse("node1\rnode2"), equalTo(doc(node("node1"), node("node2"))));
+        assertThat(parser.parse("node1\r\nnode2"), equalTo(doc(node("node1"), node("node2"))));
+        assertThat(parser.parse("node1\n\nnode2"), equalTo(doc(node("node1"), node("node2"))));
+    }
+
+    @Test
+    public void test_nestedChildNodes() {
+        KDLDocument actual = parser.parse(
+            "content { \n" +
+            "    section \"First section\" {\n" +
+            "        paragraph \"This is the first paragraph\"\n" +
+            "        paragraph \"This is the second paragraph\"\n" +
+            "    }\n" +
+            "}"
+        );
+
+        KDLDocument expected = doc(
+            node("content", 
+                node("section", List.of("First section"),
+                    node("paragraph", List.of("This is the first paragraph")),
+                    node("paragraph", List.of("This is the second paragraph"))
+                )
+            )
+        );
+
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void test_semicolon() {
+        assertThat(parser.parse("node1; node2; node3"),
+            equalTo(doc(node("node1"), node("node2"), node("node3"))));
+        assertThat(parser.parse("node1 { node2; }; node3"),
+            equalTo(doc(node("node1", node("node2")), node("node3")))); // TODO: fails
+    }
+
+    @Test
+    public void test_multiline_strings() {
+        assertThat(parser.parse("string \"my\nmultiline\nvalue\""),
+            equalTo(doc(node("string", List.of("my\nmultiline\nvalue")))));
+    }
+
+    @Test
+    public void test_comments() {
+        KDLDocument actual = parser.parse(
+            "// C style\n"+
+
+            "/*\n" +
+            "C style multiline\n" +
+            "*/\n" +
+
+            "tag /*foo=true*/ bar=false\n" +
+
+            "/*/*\n" +
+            "hello\n" +
+            "*/*/"
+        );
+
+        KDLDocument expected = doc(
+            node("tag", Map.of("bar", false))
+        );
+
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void test_multiline_nodes() {
+        KDLDocument actual = parser.parse(
+            "title \\\n" +
+            "    \"Some title\"\n" +
+
+            "my-node 1 2 \\    // comments are ok after \\\n" +
+            "        3 4\n"
+        );
+
+        KDLDocument expected = doc(
+            node("title", List.of("Some title")),
+            node("my-node", List.of(1, 2, 3, 4))
+        );
+
+        assertThat(actual, equalTo(expected)); // TODO: fails
+    }
+
+    @Test
+    public void test_utf8() {
+        assertThat(parser.parse("smile \"😁\""), equalTo(doc(node("smile", List.of("😁")))));
+        assertThat(parser.parse("ノード お名前＝\"☜(ﾟヮﾟ☜)\""),
+            equalTo(doc(node("ノード", Map.of("お名前", "☜(ﾟヮﾟ☜)"))))); // TODO: fails
+    }
+
+    @Test
+    public void test_node_names() {
+        assertThat(parser.parse("\"!@#$@$%Q#$%~@!40\" \"1.2.3\" \"!!!!!\"=true"),
+            equalTo(doc(node("!@#$@$%Q#$%~@!40", List.of("1.2.3"), Map.of("!!!!!", true)))));
+        assertThat(parser.parse("foo123~!@#$%^&*.:'|/?+ \"weeee\""),
+            equalTo(doc(node("foo123~!@#$%^&*.:'|/?+", List.of("weeee"))))); // TODO: fails
+    }
+
+    private KDLDocument doc(KDLNode... nodes) {
+        List<KDLNode> nodeList = new ArrayList<>();
+        Collections.addAll(nodeList, nodes);
+        return new KDLDocument(nodeList);
+    }
+
+    private KDLNode node(String ident, List<Object> args, Map<String, Object> props, KDLNode... nodes) {
+        List<KDLValue> argValues = new ArrayList<>();
+        for (Object o : args) {
+            argValues.add(KDLValue.from(o));
+        }
+        Map<String, KDLValue> propValues = new HashMap<>();
+        for (Map.Entry<String, Object> e : props.entrySet()) {
+            propValues.put(e.getKey(), KDLValue.from(e.getValue()));
+        }
+        Optional<KDLDocument> children = Optional.empty();
+        if (nodes.length > 0) {
+            children = Optional.of(doc(nodes));
+        }
+        return new KDLNode(ident, propValues, argValues, children);
+    }
+
+    private KDLNode node(String ident, List<Object> args, KDLNode... nodes) {
+        return node(ident, args, Collections.emptyMap(), nodes);
+    }
+
+    private KDLNode node(String ident, Map<String, Object> props, KDLNode... nodes) {
+        return node(ident, Collections.emptyList(), props, nodes);
+    }
+
+    private KDLNode node(String ident, KDLNode... nodes) {
+        return node(ident, Collections.emptyList(), nodes);
+    }
+}


### PR DESCRIPTION
I converted the tests from my ruby implementation. I managed to fix a few small issues but some of the tests are still failing.

Issues fixed:
* `MAX_UNICODE` should be `0x10FFFF`. It was missing an `F`, probably because of the typo in the spec kdl-org/kdl#72.
* Allow semicolon as a node terminator, e.g. `node1; node2, node3`. This works at least for empty nodes, but I think it falls apart when adding args, props and children.
* `\\` escape wasn't working because it was treating the second backslash as another escape.
* Added `\/`. It's not in the spec, but it's in the Rust reference implementation kdl-org/kdl#73.
* Fix unicode escapes. It was converting the int into a char, which only works for characters that can fit into a single byte, so I changed it to append the int as a code point.

New features:
* A generic `KDLValue.from` method that accepts any type. Primarily used as a helper in the tests.
* Some nice short-hands for building expected documents in `TestParser`. Feel free to move them to `TestUtils` to use them elsewhere.
* A `throwsException` hamcrest matcher to assert that a Lambda throws a given exception class.