### PR TITLE
Add shortcut methods for getting numbers/booleans

### DIFF
--- a/src/main/java/dev/hbeck/kdl/objects/KDLBoolean.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLBoolean.java
@@ -4,6 +4,7 @@ import dev.hbeck.kdl.print.PrintConfig;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -34,8 +35,18 @@ public class KDLBoolean extends KDLValue<Boolean> {
     }
 
     @Override
+    public BigDecimal getAsNumber(BigDecimal defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
     public Optional<KDLBoolean> getAsBoolean() {
         return Optional.of(this);
+    }
+
+    @Override
+    public boolean getAsBoolean(boolean defaultValue) {
+        return value;
     }
 
     @Override

--- a/src/main/java/dev/hbeck/kdl/objects/KDLBoolean.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLBoolean.java
@@ -35,7 +35,7 @@ public class KDLBoolean extends KDLValue<Boolean> {
     }
 
     @Override
-    public BigDecimal getAsNumber(BigDecimal defaultValue) {
+    public BigDecimal getAsNumberOrElse(BigDecimal defaultValue) {
         return defaultValue;
     }
 
@@ -45,7 +45,7 @@ public class KDLBoolean extends KDLValue<Boolean> {
     }
 
     @Override
-    public boolean getAsBoolean(boolean defaultValue) {
+    public boolean getAsBooleanOrElse(boolean defaultValue) {
         return value;
     }
 

--- a/src/main/java/dev/hbeck/kdl/objects/KDLNull.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLNull.java
@@ -36,7 +36,7 @@ public class KDLNull extends KDLValue<Void> {
     }
 
     @Override
-    public BigDecimal getAsNumber(BigDecimal defaultValue) {
+    public BigDecimal getAsNumberOrElse(BigDecimal defaultValue) {
         return defaultValue;
     }
 
@@ -46,7 +46,7 @@ public class KDLNull extends KDLValue<Void> {
     }
 
     @Override
-    public boolean getAsBoolean(boolean defaultValue) {
+    public boolean getAsBooleanOrElse(boolean defaultValue) {
         return defaultValue;
     }
 

--- a/src/main/java/dev/hbeck/kdl/objects/KDLNull.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLNull.java
@@ -4,6 +4,7 @@ import dev.hbeck.kdl.print.PrintConfig;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -35,8 +36,18 @@ public class KDLNull extends KDLValue<Void> {
     }
 
     @Override
+    public BigDecimal getAsNumber(BigDecimal defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
     public Optional<KDLBoolean> getAsBoolean() {
         return Optional.empty();
+    }
+
+    @Override
+    public boolean getAsBoolean(boolean defaultValue) {
+        return defaultValue;
     }
 
     @Override

--- a/src/main/java/dev/hbeck/kdl/objects/KDLNumber.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLNumber.java
@@ -48,8 +48,18 @@ public class KDLNumber extends KDLValue<BigDecimal> {
     }
 
     @Override
+    public BigDecimal getAsNumber(BigDecimal defaultValue) {
+        return value;
+    }
+
+    @Override
     public Optional<KDLBoolean> getAsBoolean() {
         return Optional.empty();
+    }
+
+    @Override
+    public boolean getAsBoolean(boolean defaultValue) {
+        return defaultValue;
     }
 
     @Override

--- a/src/main/java/dev/hbeck/kdl/objects/KDLNumber.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLNumber.java
@@ -48,7 +48,7 @@ public class KDLNumber extends KDLValue<BigDecimal> {
     }
 
     @Override
-    public BigDecimal getAsNumber(BigDecimal defaultValue) {
+    public BigDecimal getAsNumberOrElse(BigDecimal defaultValue) {
         return value;
     }
 
@@ -58,7 +58,7 @@ public class KDLNumber extends KDLValue<BigDecimal> {
     }
 
     @Override
-    public boolean getAsBoolean(boolean defaultValue) {
+    public boolean getAsBooleanOrElse(boolean defaultValue) {
         return defaultValue;
     }
 

--- a/src/main/java/dev/hbeck/kdl/objects/KDLString.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLString.java
@@ -44,7 +44,7 @@ public class KDLString extends KDLValue<String> {
     }
 
     @Override
-    public BigDecimal getAsNumber(BigDecimal defaultValue) {
+    public BigDecimal getAsNumberOrElse(BigDecimal defaultValue) {
         return defaultValue;
     }
 
@@ -54,7 +54,7 @@ public class KDLString extends KDLValue<String> {
     }
 
     @Override
-    public boolean getAsBoolean(boolean defaultValue) {
+    public boolean getAsBooleanOrElse(boolean defaultValue) {
         return defaultValue;
     }
 

--- a/src/main/java/dev/hbeck/kdl/objects/KDLString.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLString.java
@@ -5,6 +5,7 @@ import dev.hbeck.kdl.print.PrintUtil;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -43,8 +44,18 @@ public class KDLString extends KDLValue<String> {
     }
 
     @Override
+    public BigDecimal getAsNumber(BigDecimal defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
     public Optional<KDLBoolean> getAsBoolean() {
         return KDLBoolean.fromString(value, type);
+    }
+
+    @Override
+    public boolean getAsBoolean(boolean defaultValue) {
+        return defaultValue;
     }
 
     @Override

--- a/src/main/java/dev/hbeck/kdl/objects/KDLValue.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLValue.java
@@ -23,7 +23,11 @@ public abstract class KDLValue<T> implements KDLObject {
 
     public abstract Optional<KDLNumber> getAsNumber();
 
+    public abstract BigDecimal getAsNumber(BigDecimal defaultValue);
+
     public abstract Optional<KDLBoolean> getAsBoolean();
+
+    public abstract boolean getAsBoolean(boolean defaultValue);
 
     protected abstract void writeKDLValue(Writer writer, PrintConfig printConfig) throws IOException;
 

--- a/src/main/java/dev/hbeck/kdl/objects/KDLValue.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLValue.java
@@ -23,11 +23,11 @@ public abstract class KDLValue<T> implements KDLObject {
 
     public abstract Optional<KDLNumber> getAsNumber();
 
-    public abstract BigDecimal getAsNumber(BigDecimal defaultValue);
+    public abstract BigDecimal getAsNumberOrElse(BigDecimal defaultValue);
 
     public abstract Optional<KDLBoolean> getAsBoolean();
 
-    public abstract boolean getAsBoolean(boolean defaultValue);
+    public abstract boolean getAsBooleanOrElse(boolean defaultValue);
 
     protected abstract void writeKDLValue(Writer writer, PrintConfig printConfig) throws IOException;
 


### PR DESCRIPTION
Right now, if you want to get a number or boolean value from a kdl node, the process is...rather clunky. See the following code: 
```java
KDLNode node = new KDLNode.Builder().setIdentifier("node").addArg(KDLValue.from(5)).build();
int arg = node.getArgs().get(0).getAsNumber().orElse(KDLNumber.from(1)).getValue().intValue();
```

This PR adds methods which makes this cleaner
```java
KDLNode node = new KDLNode.Builder().setIdentifier("node").addArg(KDLValue.from(5)).build();
int arg = node.getArgs().get(0).getAsNumberOrElse(new BigDecimal(1)).intValue();
```

I would *like* to also refactor `KDLNumber` to `extends KDLValue<Number>` instead of `extends KDLValue<BigDecimal>` (while still deserializing KDL as `BigDecimal` by default) to make this even cleaner and more user-friendly, but that would be a breaking change which deserves its own PR.