### PR TITLE
Convert KdlNumber to expose itself as Number

### DIFF
--- a/src/main/java/dev/hbeck/kdl/objects/KDLBoolean.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLBoolean.java
@@ -35,7 +35,7 @@ public class KDLBoolean extends KDLValue<Boolean> {
     }
 
     @Override
-    public BigDecimal getAsNumberOrElse(BigDecimal defaultValue) {
+    public Number getAsNumberOrElse(Number defaultValue) {
         return defaultValue;
     }
 

--- a/src/main/java/dev/hbeck/kdl/objects/KDLNull.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLNull.java
@@ -36,7 +36,7 @@ public class KDLNull extends KDLValue<Void> {
     }
 
     @Override
-    public BigDecimal getAsNumberOrElse(BigDecimal defaultValue) {
+    public Number getAsNumberOrElse(Number defaultValue) {
         return defaultValue;
     }
 

--- a/src/main/java/dev/hbeck/kdl/objects/KDLNumber.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLNumber.java
@@ -18,13 +18,6 @@ import java.util.Optional;
 public class KDLNumber extends KDLValue<Number> {
     private final Number value;
     private final int radix;
-    /*
-    Oh, right. You technically can't compare two `Number`s. Thaaaanks, Oracle.
-    Ah, well. Just store them here as `BigDecimal`s and check equality on those.
-    I don't like it, but until Valhalla and associated JEPS are done, we've just gotta do this.
-    ~LemmaEOF
-     */
-    private final BigDecimal comparisonValue;
 
     public KDLNumber(Number value, int radix) {
         this(value, radix, Optional.empty());
@@ -34,7 +27,6 @@ public class KDLNumber extends KDLValue<Number> {
         super(type);
         this.value = Objects.requireNonNull(value);
         this.radix = radix;
-        this.comparisonValue = new BigDecimal(this.value.toString());
     }
 
     @Override
@@ -225,7 +217,13 @@ public class KDLNumber extends KDLValue<Number> {
         if (this == o) return true;
         if (!(o instanceof KDLNumber)) return false;
         KDLNumber kdlNumber = (KDLNumber) o;
-        return radix == kdlNumber.radix && Objects.equals(comparisonValue, kdlNumber.comparisonValue) && Objects.equals(type, kdlNumber.type);
+        /*
+        Oh, right. You technically can't compare two `Number`s. Thaaaanks, Oracle.
+        Ah, well. Just use `toString` and check if those are equal.
+        Numbers in Java all stringify in the same way, so this should work fine.
+        ~LemmaEOF
+         */
+        return radix == kdlNumber.radix && Objects.equals(value.toString(), kdlNumber.value.toString()) && Objects.equals(type, kdlNumber.type);
     }
 
     @Override

--- a/src/main/java/dev/hbeck/kdl/objects/KDLNumber.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLNumber.java
@@ -69,7 +69,7 @@ public class KDLNumber extends KDLValue<Number> {
         if (printConfig.shouldRespectRadix()) {
             /*
             Print out a number while respecting radix!
-            If it's binary, octal, or hex, this convert it to a `BigInteger` to format.
+            If it's binary, octal, or hex, this converts it to a `BigInteger` to format.
             This is kludge-y, but someone *might* for some reason want to have a more-than-64-bit number in KDL.
             I have no idea *why* you'd want that, but who am I to judge?
             Plus one of our test cases uses an 80-bit hex number so let's just roll with it lol

--- a/src/main/java/dev/hbeck/kdl/objects/KDLString.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLString.java
@@ -44,7 +44,7 @@ public class KDLString extends KDLValue<String> {
     }
 
     @Override
-    public BigDecimal getAsNumberOrElse(BigDecimal defaultValue) {
+    public Number getAsNumberOrElse(Number defaultValue) {
         return defaultValue;
     }
 

--- a/src/main/java/dev/hbeck/kdl/objects/KDLValue.java
+++ b/src/main/java/dev/hbeck/kdl/objects/KDLValue.java
@@ -23,7 +23,7 @@ public abstract class KDLValue<T> implements KDLObject {
 
     public abstract Optional<KDLNumber> getAsNumber();
 
-    public abstract BigDecimal getAsNumberOrElse(BigDecimal defaultValue);
+    public abstract Number getAsNumberOrElse(Number defaultValue);
 
     public abstract Optional<KDLBoolean> getAsBoolean();
 


### PR DESCRIPTION
Alright, breaking change time! This deserves a bit of a write-up, so here we go.

This PR converts `KDLNumber` to extend `KDLValue<Number>` instead of `KDLValue<BigDecimal>`. The kdl spec doesn't prescribe representation for numbers, allowing them to be treated however the implementation wants. Up to now, kdl4j has represented all numbers as `BigDecimal`s in order to preserve the arbitrary size and precision the kdl spec allows. While this is *great* for round-tripping, it can end up being a bit of a hassle - it's very rare in actual environments that you'll need or want all the precision a `BigDecimal` confers.

All number types in Java subclass `Number` at the end of the day, so the new version of the code changes the field type to just `Number`. That way, you can construct a `KDLNumber` with any numerical primitive instead of having to allocate a `BigDecimal`, and then extract numbers at whatever size you actually need, from a simple `byte` all the way up to the arbitrary precision you'd expect from the old code.

The parser code hasn't actually been changed - `KDLParser` still sends in `BigDecimal`s for decimal numbers and `BigInteger`s for non-decimal numbers. However previously the `BigInteger`s were converted to `BigDecimal`s during initialization - this is no longer the case.

There is, sadly, one catch with all of this. You can't actually check equality between arbitrary `Number` types, due to how the JVM is designed. To get around this, I convert the value to a `String` - all number types in base Java stringify to standard numeric representations, so this is a neat and tidy way to check effective equality.

This is **still a breaking change** - we are changing return types of existing methods, so code that worked previously **may fail to compile or run** with this new change. Due to most use cases wanting to use `Number` methods to quick-escape from `BigDecimal` land, though, I expect at least some code to still work just fine. I recommend at least a minor version change for this, if not a major version change.

I've run the current test suite and everything looks to pass just fine! I planned to add tests but the tests currently in manage to check the expected corner-cases (>64-bit numbers, comparing `Number`s of different types, etc.) just fine. This is review-ready!